### PR TITLE
Implement Hamming codec tables and decoder

### DIFF
--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -51,3 +51,14 @@
 **Next**
 - Implement spec-accurate **Hamming** (CR 4/5..4/8) and **Diagonal Interleaver** (incl. LDRO) + unit tests (SF7..SF12).
 - Add `scripts/export_vectors.sh` to generate known-good vectors from `gr_lora_sdr` for cross-validation.
+
+## 2025-09-03 — Hamming codec complete
+
+**Done**
+- Replaced placeholder with generated Hamming (4,n) tables and syndrome maps.
+- Added decode path correcting single-bit errors (CR4/7,4/8) and detecting errors for CR4/5 and CR4/6.
+- Expanded unit tests to cover all coding rates.
+
+**Next**
+- Implement diagonal interleaver patterns and associated unit tests.
+- Cross-validate utilities against reference vectors from `gr_lora_sdr`.

--- a/include/lora/utils/hamming.hpp
+++ b/include/lora/utils/hamming.hpp
@@ -7,6 +7,14 @@
 
 namespace lora::utils {
 
+// LoRa uses a systematic (4, n) block code derived from the classic
+// Hamming (7,4) with an additional overall parity bit for n = 8.  The
+// coding rate CR = 4/n selects how many parity bits are appended after
+// the four data bits of a nibble.
+//   * CR45 and CR46 provide single-bit error *detection*.
+//   * CR47 corrects any single-bit error within the 7-bit codeword.
+//   * CR48 corrects any single-bit error and detects any double-bit error.
+
 enum class CodeRate : uint8_t { CR45 = 1, CR46 = 2, CR47 = 3, CR48 = 4 };
 
 struct HammingTables {
@@ -14,12 +22,27 @@ struct HammingTables {
     std::array<uint8_t, 16> enc_46{}; // 6-bit packed
     std::array<uint8_t, 16> enc_47{}; // 7-bit packed
     std::array<uint8_t, 16> enc_48{}; // 8-bit packed
+
+    // Syndrome lookup tables.  Index by the syndrome value to obtain the
+    // bit position that should be flipped to correct a single-bit error.
+    // Entries are -1 for invalid/unmapped syndromes.
+    std::array<int8_t, 2>  synd_45{}; // unused (detect only)
+    std::array<int8_t, 4>  synd_46{}; // unused (detect only)
+    std::array<int8_t, 8>  synd_47{};
+    std::array<int8_t, 16> synd_48{};
 };
 
-HammingTables make_placeholder_tables();
+HammingTables make_hamming_tables();
 
+// Encode a 4-bit nibble according to the selected coding rate.  Returns the
+// packed codeword and the number of valid bits in it.
 std::pair<uint16_t, uint8_t> hamming_encode4(uint8_t nibble, CodeRate cr, const HammingTables& T);
 
+// Decode a packed codeword produced by ::hamming_encode4().  On success
+// returns the recovered nibble and whether a single-bit error was corrected.
+// For CR45 and CR46 a non-zero syndrome results in std::nullopt.  For CR47
+// a single-bit error is corrected.  For CR48 single-bit errors are corrected
+// and any double-bit error results in std::nullopt.
 std::optional<std::pair<uint8_t, bool>> hamming_decode4(uint16_t codeword, uint8_t nbits, CodeRate cr, const HammingTables& T);
 
 } // namespace lora::utils

--- a/src/utils/hamming.cpp
+++ b/src/utils/hamming.cpp
@@ -1,5 +1,6 @@
 #include "lora/utils/hamming.hpp"
 #include <cassert>
+#include <cstring>
 
 namespace lora::utils {
 
@@ -9,18 +10,62 @@ static uint8_t parity(uint32_t v) {
     return lut[v];
 }
 
-HammingTables make_placeholder_tables() {
+static uint8_t compute_syndrome(uint16_t cw, uint8_t nbits) {
+    uint8_t d0 = (cw >> 0) & 1;
+    uint8_t d1 = (cw >> 1) & 1;
+    uint8_t d2 = (cw >> 2) & 1;
+    uint8_t d3 = (cw >> 3) & 1;
+    uint8_t p1 = (cw >> 4) & 1;
+    uint8_t p2 = (cw >> 5) & 1;
+    uint8_t p3 = (cw >> 6) & 1;
+    uint8_t p0 = (cw >> 7) & 1;
+
+    uint8_t s1 = (d0 ^ d1 ^ d3) ^ p1;
+    uint8_t s2 = (nbits >= 6) ? ((d0 ^ d2 ^ d3) ^ p2) : 0;
+    uint8_t s3 = (nbits >= 7) ? ((d1 ^ d2 ^ d3) ^ p3) : 0;
+    uint8_t s0 = (nbits == 8) ? parity(cw & 0xFFu) : 0;
+
+    return static_cast<uint8_t>((s0 << 3) | (s3 << 2) | (s2 << 1) | s1);
+}
+
+HammingTables make_hamming_tables() {
     HammingTables T;
+    T.synd_45.fill(-1);
+    T.synd_46.fill(-1);
+    T.synd_47.fill(-1);
+    T.synd_48.fill(-1);
+
     for (int d = 0; d < 16; ++d) {
-        uint8_t p  = parity(d);
-        uint8_t p1 = parity(d ^ 0b1011);
-        uint8_t p2 = parity(d ^ 0b0110);
-        uint8_t p3 = parity(d ^ 0b1101);
-        T.enc_45[d] = ((d & 0xF) | (p  << 4));
-        T.enc_46[d] = ((d & 0xF) | (p  << 4) | (p1 << 5));
-        T.enc_47[d] = ((d & 0xF) | (p  << 4) | (p1 << 5) | (p2 << 6));
-        T.enc_48[d] = ((d & 0xF) | (p  << 4) | (p1 << 5) | (p2 << 6) | (p3 << 7));
+        uint8_t d0 = (d >> 0) & 1;
+        uint8_t d1 = (d >> 1) & 1;
+        uint8_t d2 = (d >> 2) & 1;
+        uint8_t d3 = (d >> 3) & 1;
+
+        uint8_t p1 = d0 ^ d1 ^ d3;              // Hamming parity bits
+        uint8_t p2 = d0 ^ d2 ^ d3;
+        uint8_t p3 = d1 ^ d2 ^ d3;
+        uint8_t p0 = d0 ^ d1 ^ d2 ^ d3 ^ p1 ^ p2 ^ p3; // overall parity
+
+        T.enc_45[d] = static_cast<uint8_t>((d & 0xF) | (p1 << 4));
+        T.enc_46[d] = static_cast<uint8_t>((d & 0xF) | (p1 << 4) | (p2 << 5));
+        T.enc_47[d] = static_cast<uint8_t>((d & 0xF) | (p1 << 4) | (p2 << 5) | (p3 << 6));
+        T.enc_48[d] = static_cast<uint8_t>((d & 0xF) | (p1 << 4) | (p2 << 5) | (p3 << 6) | (p0 << 7));
     }
+
+    auto fill_dec = [](auto& arr, uint8_t nbits) {
+        uint16_t base = 0; // encode(0) == 0
+        for (int i = 0; i < nbits; ++i) {
+            uint16_t cw = base ^ (1u << i);
+            uint8_t syn = compute_syndrome(cw, nbits);
+            if (syn < arr.size()) arr[syn] = static_cast<int8_t>(i);
+        }
+    };
+
+    fill_dec(T.synd_45, 5);
+    fill_dec(T.synd_46, 6);
+    fill_dec(T.synd_47, 7);
+    fill_dec(T.synd_48, 8);
+
     return T;
 }
 
@@ -35,9 +80,35 @@ std::pair<uint16_t, uint8_t> hamming_encode4(uint8_t nibble, CodeRate cr, const 
     return {0,0};
 }
 
-std::optional<std::pair<uint8_t, bool>> hamming_decode4(uint16_t codeword, uint8_t, CodeRate, const HammingTables&) {
-    uint8_t nibble = codeword & 0xF;
-    return std::make_optional(std::make_pair(nibble, false));
+std::optional<std::pair<uint8_t, bool>> hamming_decode4(uint16_t codeword, uint8_t nbits, CodeRate cr, const HammingTables& T) {
+    codeword &= (1u << nbits) - 1u;
+    uint8_t syn = compute_syndrome(codeword, nbits);
+    uint8_t nibble = static_cast<uint8_t>(codeword & 0xF);
+
+    switch (cr) {
+        case CodeRate::CR45:
+        case CodeRate::CR46:
+            if (syn) return std::nullopt;
+            return std::make_optional(std::make_pair(nibble, false));
+
+        case CodeRate::CR47: {
+            if (syn == 0) return std::make_optional(std::make_pair(nibble, false));
+            int8_t idx = T.synd_47[syn];
+            if (idx < 0) return std::nullopt;
+            codeword ^= (1u << idx);
+            nibble = static_cast<uint8_t>(codeword & 0xF);
+            return std::make_optional(std::make_pair(nibble, true));
+        }
+        case CodeRate::CR48: {
+            if (syn == 0) return std::make_optional(std::make_pair(nibble, false));
+            int8_t idx = T.synd_48[syn];
+            if (idx < 0) return std::nullopt;
+            codeword ^= (1u << idx);
+            nibble = static_cast<uint8_t>(codeword & 0xF);
+            return std::make_optional(std::make_pair(nibble, true));
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace lora::utils

--- a/tests/test_hamming.cpp
+++ b/tests/test_hamming.cpp
@@ -2,12 +2,51 @@
 #include "lora/utils/hamming.hpp"
 using namespace lora::utils;
 
-TEST(Hamming, EncodeDecodePlaceholder) {
-    auto T = make_placeholder_tables();
+TEST(Hamming, EncodeDecodeAllRates) {
+    auto T = make_hamming_tables();
     for (int d = 0; d < 16; ++d) {
-        auto [cw5, n5] = hamming_encode4(d, CodeRate::CR45, T);
-        auto dec5 = hamming_decode4(cw5, n5, CodeRate::CR45, T);
-        ASSERT_TRUE(dec5.has_value());
-        EXPECT_EQ(dec5->first, (d & 0xF));
+        for (CodeRate cr : {CodeRate::CR45, CodeRate::CR46, CodeRate::CR47, CodeRate::CR48}) {
+            auto [cw, n] = hamming_encode4(d, cr, T);
+            auto dec = hamming_decode4(cw, n, cr, T);
+            ASSERT_TRUE(dec.has_value());
+            EXPECT_EQ(dec->first, (d & 0xF));
+            EXPECT_FALSE(dec->second);
+        }
     }
+}
+
+TEST(Hamming, DetectOrCorrect) {
+    auto T = make_hamming_tables();
+
+    // CR 4/5 detection
+    auto [cw5, n5] = hamming_encode4(0xA, CodeRate::CR45, T);
+    cw5 ^= 1u << 0; // flip a bit
+    EXPECT_FALSE(hamming_decode4(cw5, n5, CodeRate::CR45, T).has_value());
+
+    // CR 4/6 detection
+    auto [cw6, n6] = hamming_encode4(0xA, CodeRate::CR46, T);
+    cw6 ^= 1u << 0;
+    EXPECT_FALSE(hamming_decode4(cw6, n6, CodeRate::CR46, T).has_value());
+
+    // CR 4/7 correction
+    auto [cw7, n7] = hamming_encode4(0xA, CodeRate::CR47, T);
+    for (int i = 0; i < n7; ++i) {
+        auto cw_err = cw7 ^ (1u << i);
+        auto dec = hamming_decode4(cw_err, n7, CodeRate::CR47, T);
+        ASSERT_TRUE(dec.has_value());
+        EXPECT_EQ(dec->first, 0xA & 0xF);
+        EXPECT_TRUE(dec->second);
+    }
+
+    // CR 4/8 correction + double-error detection
+    auto [cw8, n8] = hamming_encode4(0xA, CodeRate::CR48, T);
+    for (int i = 0; i < n8; ++i) {
+        auto cw_err = cw8 ^ (1u << i);
+        auto dec = hamming_decode4(cw_err, n8, CodeRate::CR48, T);
+        ASSERT_TRUE(dec.has_value());
+        EXPECT_EQ(dec->first, 0xA & 0xF);
+        EXPECT_TRUE(dec->second);
+    }
+    auto dbl = cw8 ^ 0x3u; // two-bit error
+    EXPECT_FALSE(hamming_decode4(dbl, n8, CodeRate::CR48, T).has_value());
 }


### PR DESCRIPTION
## Summary
- generate LoRa-compliant Hamming (4,n) encode tables and syndrome maps
- add single-bit correcting decoder with detection for all coding rates
- expand unit tests for all code rates and document API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b67fb51eb88329a988ee955d17de3c