### PR TITLE
Add TX/RX loopback pipeline with workspace and end-to-end tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ add_library(lora_utils
 )
 target_include_directories(lora_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# ---------- Library: lora_phy (tx/rx loopback) ----------
+add_library(lora_phy
+    src/workspace.cpp
+    src/tx/loopback_tx.cpp
+    src/rx/loopback_rx.cpp
+)
+target_link_libraries(lora_phy PUBLIC lora_utils)
+target_include_directories(lora_phy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # ---------- Tests ----------
 enable_testing()
 include(GoogleTest)
@@ -53,3 +62,7 @@ gtest_discover_tests(test_crc)
 add_executable(test_header_crc tests/test_header_crc.cpp)
 target_link_libraries(test_header_crc PRIVATE lora_utils GTest::gtest_main)
 gtest_discover_tests(test_header_crc)
+
+add_executable(test_loopback tests/test_loopback.cpp)
+target_link_libraries(test_loopback PRIVATE lora_phy GTest::gtest_main)
+gtest_discover_tests(test_loopback)

--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -73,3 +73,13 @@
 **Next**
 - Cross-validate interleaver patterns against `gr_lora_sdr` vectors.
 - Prepare TX→RX loopback harness integrating utilities.
+
+## 2025-09-05 — Milestone 2: Loopback Harness
+
+**Done**
+- Added workspace with one-time allocation of chirps, buffers, and FFT plan.
+- Implemented TX and RX loopback modules chaining whitening, Hamming FEC, interleaving, Gray map, and chirp modulation with reciprocal demodulation.
+- Created end-to-end loopback test covering SF7–SF12 and CR 4/5–4/8.
+
+**Next**
+- Cross-validate against `gr_lora_sdr` vectors.

--- a/include/lora/rx/loopback_rx.hpp
+++ b/include/lora/rx/loopback_rx.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <vector>
+#include <complex>
+#include <cstdint>
+#include <utility>
+#include "lora/workspace.hpp"
+#include "lora/utils/hamming.hpp"
+
+namespace lora::rx {
+
+std::pair<std::vector<uint8_t>, bool> loopback_rx(Workspace& ws,
+                                                  const std::vector<std::complex<float>>& samples,
+                                                  uint32_t sf,
+                                                  utils::CodeRate cr,
+                                                  size_t payload_len);
+
+} // namespace lora::rx
+

--- a/include/lora/tx/loopback_tx.hpp
+++ b/include/lora/tx/loopback_tx.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <complex>
+#include <cstdint>
+#include "lora/workspace.hpp"
+#include "lora/utils/hamming.hpp"
+
+namespace lora::tx {
+
+std::vector<std::complex<float>> loopback_tx(Workspace& ws,
+                                             const std::vector<uint8_t>& payload,
+                                             uint32_t sf,
+                                             utils::CodeRate cr);
+
+} // namespace lora::tx
+

--- a/include/lora/workspace.hpp
+++ b/include/lora/workspace.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include <complex>
+
+namespace lora {
+
+struct FftPlan {
+    uint32_t N{};
+    uint32_t log2N{};
+    std::vector<std::complex<float>> twiddles; // N/2 twiddles
+    std::vector<uint32_t> bitrev;               // N indices
+};
+
+struct Workspace {
+    uint32_t sf{};
+    uint32_t N{};
+    FftPlan plan;
+    std::vector<std::complex<float>> upchirp;
+    std::vector<std::complex<float>> downchirp;
+    std::vector<std::complex<float>> rxbuf;
+    std::vector<std::complex<float>> fftbuf;
+
+    void init(uint32_t new_sf);
+    void fft(const std::complex<float>* in, std::complex<float>* out) const;
+};
+
+} // namespace lora
+

--- a/src/rx/loopback_rx.cpp
+++ b/src/rx/loopback_rx.cpp
@@ -1,0 +1,97 @@
+#include "lora/rx/loopback_rx.hpp"
+#include "lora/utils/whitening.hpp"
+#include "lora/utils/interleaver.hpp"
+#include "lora/utils/gray.hpp"
+#include "lora/utils/crc.hpp"
+#include <cmath>
+
+using namespace lora::utils;
+
+namespace lora::rx {
+
+std::pair<std::vector<uint8_t>, bool> loopback_rx(Workspace& ws,
+                                                  const std::vector<std::complex<float>>& samples,
+                                                  uint32_t sf,
+                                                  CodeRate cr,
+                                                  size_t payload_len) {
+    ws.init(sf);
+    uint32_t N = ws.N;
+    uint32_t cr_plus4 = static_cast<uint32_t>(cr) + 4;
+    size_t nsym = samples.size() / N;
+
+    // Demodulate symbols
+    std::vector<uint32_t> symbols;
+    symbols.reserve(nsym);
+    for (size_t s_idx = 0; s_idx < nsym; ++s_idx) {
+        const std::complex<float>* block = &samples[s_idx * N];
+        for (uint32_t n = 0; n < N; ++n)
+            ws.rxbuf[n] = block[n] * ws.downchirp[n];
+        ws.fft(ws.rxbuf.data(), ws.fftbuf.data());
+        uint32_t max_bin = 0;
+        float max_mag = 0.f;
+        for (uint32_t k = 0; k < N; ++k) {
+            float mag = std::norm(ws.fftbuf[k]);
+            if (mag > max_mag) {
+                max_mag = mag;
+                max_bin = k;
+            }
+        }
+        symbols.push_back(gray_decode(max_bin));
+    }
+
+    // Symbols -> bits
+    std::vector<uint8_t> bits;
+    bits.reserve(symbols.size() * sf);
+    for (uint32_t sym : symbols) {
+        for (uint32_t b = 0; b < sf; ++b)
+            bits.push_back((sym >> b) & 1);
+    }
+
+    // Deinterleave
+    InterleaverMap M = make_diagonal_interleaver(sf, cr_plus4);
+    std::vector<uint8_t> deint(bits.size());
+    for (size_t off = 0; off < bits.size(); off += M.n_in) {
+        for (uint32_t i = 0; i < M.n_out; ++i)
+            deint[off + M.map[i]] = bits[off + i];
+    }
+
+    // Hamming decode
+    static HammingTables T = make_hamming_tables();
+    std::vector<uint8_t> nibbles;
+    for (size_t i = 0; i < deint.size(); i += cr_plus4) {
+        uint16_t cw = 0;
+        for (uint32_t b = 0; b < cr_plus4; ++b)
+            cw = (cw << 1) | deint[i + b];
+        auto dec = hamming_decode4(cw, cr_plus4, cr, T);
+        if (!dec)
+            return {{}, false};
+        nibbles.push_back(dec->first & 0x0F);
+    }
+
+    // Combine nibbles -> bytes
+    std::vector<uint8_t> data((nibbles.size() + 1) / 2);
+    for (size_t i = 0; i < data.size(); ++i) {
+        uint8_t low  = (i * 2 < nibbles.size()) ? nibbles[i * 2] : 0;
+        uint8_t high = (i * 2 + 1 < nibbles.size()) ? nibbles[i * 2 + 1] : 0;
+        data[i] = (high << 4) | low;
+    }
+    size_t total_needed = payload_len + 2;
+    if (data.size() < total_needed)
+        return {{}, false};
+    data.resize(total_needed);
+
+    // Dewhiten
+    auto lfsr = LfsrWhitening::pn9_default();
+    lfsr.apply(data.data(), data.size());
+
+    // CRC verify
+    Crc16Ccitt crc16;
+    auto ver = crc16.verify_with_trailer_be(data.data(), payload_len + 2);
+    if (!ver.first)
+        return {{}, false};
+    data.resize(payload_len);
+    return {data, true};
+}
+
+} // namespace lora::rx
+

--- a/src/tx/loopback_tx.cpp
+++ b/src/tx/loopback_tx.cpp
@@ -1,0 +1,79 @@
+#include "lora/tx/loopback_tx.hpp"
+#include "lora/utils/whitening.hpp"
+#include "lora/utils/interleaver.hpp"
+#include "lora/utils/gray.hpp"
+#include "lora/utils/crc.hpp"
+#include <cmath>
+
+using namespace lora::utils;
+
+namespace lora::tx {
+
+std::vector<std::complex<float>> loopback_tx(Workspace& ws,
+                                             const std::vector<uint8_t>& payload,
+                                             uint32_t sf,
+                                             CodeRate cr) {
+    ws.init(sf);
+    uint32_t N = ws.N;
+    uint32_t cr_plus4 = static_cast<uint32_t>(cr) + 4;
+
+    // Assemble payload + CRC
+    std::vector<uint8_t> data = payload;
+    Crc16Ccitt crc16;
+    auto trailer = crc16.make_trailer_be(data.data(), data.size());
+    data.push_back(trailer.first);
+    data.push_back(trailer.second);
+
+    // Whitening
+    auto lfsr = LfsrWhitening::pn9_default();
+    lfsr.apply(data.data(), data.size());
+
+    // Hamming encode -> bit vector
+    static HammingTables T = make_hamming_tables();
+    std::vector<uint8_t> bits;
+    bits.reserve(data.size() * 2 * cr_plus4);
+    for (uint8_t b : data) {
+        uint8_t n1 = b & 0x0F;
+        uint8_t n2 = b >> 4;
+        auto enc1 = hamming_encode4(n1, cr, T);
+        auto enc2 = hamming_encode4(n2, cr, T);
+        for (int i = enc1.second - 1; i >= 0; --i)
+            bits.push_back((enc1.first >> i) & 1);
+        for (int i = enc2.second - 1; i >= 0; --i)
+            bits.push_back((enc2.first >> i) & 1);
+    }
+
+    // Pad to multiple of block size
+    uint32_t block_bits = sf * cr_plus4;
+    if (bits.size() % block_bits)
+        bits.resize((bits.size() / block_bits + 1) * block_bits, 0);
+
+    // Interleave
+    InterleaverMap M = make_diagonal_interleaver(sf, cr_plus4);
+    std::vector<uint8_t> inter(bits.size());
+    for (size_t off = 0; off < bits.size(); off += M.n_in) {
+        for (uint32_t i = 0; i < M.n_out; ++i)
+            inter[off + i] = bits[off + M.map[i]];
+    }
+
+    // Bits -> Gray-mapped symbols
+    std::vector<uint32_t> symbols;
+    for (size_t i = 0; i < inter.size(); i += sf) {
+        uint32_t val = 0;
+        for (uint32_t b = 0; b < sf; ++b)
+            val |= (uint32_t(inter[i + b]) << b);
+        symbols.push_back(gray_encode(val));
+    }
+
+    // Modulate symbols into chirps
+    std::vector<std::complex<float>> out(symbols.size() * N);
+    for (size_t s_idx = 0; s_idx < symbols.size(); ++s_idx) {
+        uint32_t sym = symbols[s_idx] & (N - 1);
+        for (uint32_t n = 0; n < N; ++n)
+            out[s_idx * N + n] = ws.upchirp[(n + sym) % N];
+    }
+    return out;
+}
+
+} // namespace lora::tx
+

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,0 +1,69 @@
+#include "lora/workspace.hpp"
+#include <cmath>
+
+namespace lora {
+
+static uint32_t bit_reverse(uint32_t x, uint32_t nbits) {
+    uint32_t r = 0;
+    for (uint32_t i = 0; i < nbits; ++i) {
+        r = (r << 1) | (x & 1);
+        x >>= 1;
+    }
+    return r;
+}
+
+void Workspace::init(uint32_t new_sf) {
+    if (sf == new_sf && N != 0)
+        return;
+    sf = new_sf;
+    N  = 1u << sf;
+
+    // FFT plan
+    plan.N      = N;
+    plan.log2N  = sf;
+    plan.twiddles.resize(N / 2);
+    plan.bitrev.resize(N);
+    const float two_pi_over_N = -2.0f * static_cast<float>(M_PI) / N;
+    for (uint32_t k = 0; k < N / 2; ++k)
+        plan.twiddles[k] = std::exp(std::complex<float>(0.0f, two_pi_over_N * k));
+    for (uint32_t i = 0; i < N; ++i)
+        plan.bitrev[i] = bit_reverse(i, sf);
+
+    // Buffers and chirps
+    upchirp.resize(N);
+    downchirp.resize(N);
+    rxbuf.resize(N);
+    fftbuf.resize(N);
+    for (uint32_t n = 0; n < N; ++n) {
+        float phase = static_cast<float>(M_PI) * n * n / N;
+        upchirp[n]   = std::exp(std::complex<float>(0.0f, phase));
+        downchirp[n] = std::conj(upchirp[n]);
+    }
+}
+
+void Workspace::fft(const std::complex<float>* in, std::complex<float>* out) const {
+    const uint32_t N = plan.N;
+    const uint32_t log2N = plan.log2N;
+
+    // Bit-reverse copy
+    for (uint32_t i = 0; i < N; ++i)
+        out[plan.bitrev[i]] = in[i];
+
+    // Iterative Cooley-Tukey
+    for (uint32_t s = 1; s <= log2N; ++s) {
+        uint32_t m  = 1u << s;
+        uint32_t m2 = m >> 1;
+        uint32_t step = N / m;
+        for (uint32_t k = 0; k < N; k += m) {
+            for (uint32_t j = 0; j < m2; ++j) {
+                auto t = plan.twiddles[j * step] * out[k + j + m2];
+                auto u = out[k + j];
+                out[k + j]       = u + t;
+                out[k + j + m2]  = u - t;
+            }
+        }
+    }
+}
+
+} // namespace lora
+

--- a/tests/test_loopback.cpp
+++ b/tests/test_loopback.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <random>
+#include "lora/tx/loopback_tx.hpp"
+#include "lora/rx/loopback_rx.hpp"
+#include "lora/workspace.hpp"
+
+using namespace lora;
+using namespace lora::utils;
+
+TEST(Loopback, TxRx) {
+    std::mt19937 rng(1234);
+    std::uniform_int_distribution<int> dist(0, 255);
+    Workspace ws;
+    std::vector<uint8_t> payload(16);
+    for (uint32_t sf = 7; sf <= 12; ++sf) {
+        for (CodeRate cr : {CodeRate::CR45, CodeRate::CR46, CodeRate::CR47, CodeRate::CR48}) {
+            for (auto& b : payload) b = dist(rng);
+            auto txsig = tx::loopback_tx(ws, payload, sf, cr);
+            auto rxres = rx::loopback_rx(ws, txsig, sf, cr, payload.size());
+            EXPECT_TRUE(rxres.second);
+            EXPECT_EQ(rxres.first, payload);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement workspace with preallocated buffers, FFT plan, and upchirps
- Add TX/RX loopback modules chaining whitening, Hamming FEC, interleaving, Gray map, and chirp modulation
- Introduce end-to-end loopback test across SF7–SF12 and CR 4/5–4/8

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b6883a5eb08329a6874e15a8b355e8