### PR TITLE
Add CRC golden vector test

### DIFF
--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -83,3 +83,11 @@
 
 **Next**
 - Cross-validate against `gr_lora_sdr` vectors.
+
+## 2025-09-06 — CRC cross-validation
+
+**Done**
+- Verified CRC-16 CCITT parameters against reference payload "123456789" (expected 0x29B1) and added golden unit test.
+
+**Next**
+- Export test vectors from `gr_lora_sdr` and validate TX/RX paths against them.

--- a/tests/test_crc.cpp
+++ b/tests/test_crc.cpp
@@ -16,3 +16,10 @@ TEST(CRC16, RoundtripTrailerBE) {
     auto [ok, calc] = crc.verify_with_trailer_be(payload.data(), payload.size());
     EXPECT_TRUE(ok) << std::hex << calc;
 }
+
+TEST(CRC16, KnownVector) {
+    Crc16Ccitt crc{};
+    const char* msg = "123456789";
+    uint16_t calc = crc.compute(reinterpret_cast<const uint8_t*>(msg), 9);
+    EXPECT_EQ(calc, 0x29B1);
+}


### PR DESCRIPTION
## Summary
- add deterministic CRC-16 CCITT test vector to ensure parameters match LoRa spec
- log CRC cross-validation in project notes

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b67de20c3c8329a875b5de949ee476