### PR TITLE
Add negative CRC roundtrip test for bit flip detection

### DIFF
--- a/tests/test_crc.cpp
+++ b/tests/test_crc.cpp
@@ -15,6 +15,13 @@ TEST(CRC16, RoundtripTrailerBE) {
 
     auto [ok, calc] = crc.verify_with_trailer_be(payload.data(), payload.size());
     EXPECT_TRUE(ok) << std::hex << calc;
+
+    // LoRa CRC expects detection of single-bit errors; flipping any bit should
+    // invalidate the checksum.
+    auto corrupt = payload;
+    corrupt[0] ^= 0x01;
+    auto [ok_corrupt, calc_corrupt] = crc.verify_with_trailer_be(corrupt.data(), corrupt.size());
+    EXPECT_FALSE(ok_corrupt) << std::hex << calc_corrupt;
 }
 
 TEST(CRC16, KnownVector) {


### PR DESCRIPTION
## Summary
- expand CRC16 roundtrip test to duplicate payload and flip a bit
- assert verify_with_trailer_be fails when bit is flipped, noting LoRa CRC expectations

## Testing
- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j"$(nproc)"`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b7989862b48329a349e39ff13efa10