### PR TITLE
Add regression tests for whitening edge patterns

### DIFF
--- a/tests/test_whitening.cpp
+++ b/tests/test_whitening.cpp
@@ -4,6 +4,12 @@
 #include <cstdint>
 using namespace lora::utils;
 
+// Whitening must be reversible for any input.  Uniform patterns of all zeroes or
+// ones are particularly important regression cases because earlier
+// implementations mishandled the PN sequence reset, producing data-dependent
+// corruption.  These tests make sure that whitening remains an involution even
+// for those edge cases.
+
 TEST(Whitening, Roundtrip) {
     std::vector<uint8_t> buf(1024);
     for (size_t i = 0; i < buf.size(); ++i) buf[i] = static_cast<uint8_t>(i * 31u + 7u);
@@ -16,4 +22,25 @@ TEST(Whitening, Roundtrip) {
     w2.apply(enc.data(), enc.size()); // dewhiten = whiten שוב
 
     EXPECT_EQ(enc, buf);
+}
+
+namespace {
+void roundtrip_pattern(size_t len, uint8_t value) {
+    std::vector<uint8_t> buf(len, value);
+    auto w1 = LfsrWhitening::pn9_default();
+    auto w2 = LfsrWhitening::pn9_default();
+    std::vector<uint8_t> enc = buf;
+    w1.apply(enc.data(), enc.size());
+    w2.apply(enc.data(), enc.size());
+    EXPECT_EQ(enc, buf);
+}
+} // namespace
+
+TEST(Whitening, UniformPatternsRegression) {
+    roundtrip_pattern(1, 0x00);
+    roundtrip_pattern(20, 0x00);
+    roundtrip_pattern(255, 0x00);
+    roundtrip_pattern(1, 0xFF);
+    roundtrip_pattern(20, 0xFF);
+    roundtrip_pattern(255, 0xFF);
 }


### PR DESCRIPTION
## Summary
- add regression tests for whitening on zero- and 0xFF-filled buffers
- ensure double application of whitening restores original data

## Testing
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b79a6e66048329b53a21ce2afa4123