### PR TITLE
Cache interleaver maps and return span from RX path

### DIFF
--- a/include/lora/rx/loopback_rx.hpp
+++ b/include/lora/rx/loopback_rx.hpp
@@ -9,11 +9,11 @@
 
 namespace lora::rx {
 
-std::pair<std::vector<uint8_t>, bool> loopback_rx(Workspace& ws,
-                                                  std::span<const std::complex<float>> samples,
-                                                  uint32_t sf,
-                                                  utils::CodeRate cr,
-                                                  size_t payload_len);
+std::pair<std::span<uint8_t>, bool> loopback_rx(Workspace& ws,
+                                                std::span<const std::complex<float>> samples,
+                                                uint32_t sf,
+                                                utils::CodeRate cr,
+                                                size_t payload_len);
 
 } // namespace lora::rx
 

--- a/include/lora/workspace.hpp
+++ b/include/lora/workspace.hpp
@@ -2,7 +2,9 @@
 #include <cstdint>
 #include <vector>
 #include <complex>
+#include <unordered_map>
 #include <liquid/liquid.h>
+#include "lora/utils/interleaver.hpp"
 
 using liquid_fftplan = fftplan;
 
@@ -30,11 +32,15 @@ struct Workspace {
     std::vector<uint32_t> tx_symbols;
     std::vector<std::complex<float>> tx_iq;
 
+    // Cached interleaver maps indexed by (sf << 8) | cr_plus4
+    std::unordered_map<uint32_t, lora::utils::InterleaverMap> interleavers;
+
     ~Workspace();
     void init(uint32_t new_sf);
     void fft(const std::complex<float>* in, std::complex<float>* out);
     void ensure_rx_buffers(size_t nsym, uint32_t sf, uint32_t cr_plus4);
     void ensure_tx_buffers(size_t payload_len, uint32_t sf, uint32_t cr_plus4);
+    const lora::utils::InterleaverMap& get_interleaver(uint32_t sf, uint32_t cr_plus4);
 };
 
 } // namespace lora

--- a/src/tx/loopback_tx.cpp
+++ b/src/tx/loopback_tx.cpp
@@ -1,6 +1,5 @@
 #include "lora/tx/loopback_tx.hpp"
 #include "lora/utils/whitening.hpp"
-#include "lora/utils/interleaver.hpp"
 #include "lora/utils/gray.hpp"
 #include "lora/utils/crc.hpp"
 #include <cmath>
@@ -51,7 +50,7 @@ std::span<const std::complex<float>> loopback_tx(Workspace& ws,
     }
 
     // Interleave
-    lora::utils::InterleaverMap M = lora::utils::make_diagonal_interleaver(sf, cr_plus4);
+    const auto& M = ws.get_interleaver(sf, cr_plus4);
     auto& inter = ws.tx_inter;
     for (size_t off = 0; off < nbits; off += M.n_in) {
         for (uint32_t i = 0; i < M.n_out; ++i)

--- a/tests/awgn_sweep.cpp
+++ b/tests/awgn_sweep.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <span>
+#include <algorithm>
 
 using namespace lora;
 using namespace lora::utils;
@@ -192,7 +193,9 @@ TEST(AWGN, SNR_Sweep) {
                                std::complex<float>(noise(rng), noise(rng));
 
                 auto rxres = rx::loopback_rx(ws, noisy, g_cfg.sf, cr, payload.size());
-                bool frame_ok = rxres.second && rxres.first == payload;
+                bool frame_ok = rxres.second &&
+                                rxres.first.size() == payload.size() &&
+                                std::equal(rxres.first.begin(), rxres.first.end(), payload.begin());
                 if (!frame_ok)
                     frame_errors++;
                 if (rxres.second && rxres.first.size() == payload.size()) {

--- a/tests/test_loopback.cpp
+++ b/tests/test_loopback.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <random>
+#include <algorithm>
 #include "lora/tx/loopback_tx.hpp"
 #include "lora/rx/loopback_rx.hpp"
 #include "lora/workspace.hpp"
@@ -18,7 +19,8 @@ TEST(Loopback, TxRx) {
             auto txsig = tx::loopback_tx(ws, payload, sf, cr);
             auto rxres = rx::loopback_rx(ws, txsig, sf, cr, payload.size());
             EXPECT_TRUE(rxres.second);
-            EXPECT_EQ(rxres.first, payload);
+            ASSERT_EQ(rxres.first.size(), payload.size());
+            EXPECT_TRUE(std::equal(rxres.first.begin(), rxres.first.end(), payload.begin()));
         }
     }
 }

--- a/tests/test_reference_vectors.cpp
+++ b/tests/test_reference_vectors.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <algorithm>
 
 using namespace lora;
 using namespace lora::tx;
@@ -45,7 +46,8 @@ TEST(ReferenceVectors, CrossValidate) {
         SCOPED_TRACE(name);
         auto rx = lora::rx::loopback_rx(ws, iq, sf, cr_enum, payload.size());
         ASSERT_TRUE(rx.second);
-        EXPECT_EQ(rx.first, payload);
+        ASSERT_EQ(rx.first.size(), payload.size());
+        EXPECT_TRUE(std::equal(rx.first.begin(), rx.first.end(), payload.begin()));
         auto tx_iq = lora::tx::loopback_tx(ws, payload, sf, cr_enum);
         ASSERT_EQ(tx_iq.size(), iq.size());
         for (size_t i = 0; i < iq.size(); ++i) {


### PR DESCRIPTION
## Summary
- cache diagonal interleaver maps in `Workspace` keyed by `(sf, cr)` and reuse them across tx/rx
- have `loopback_rx` return a `std::span` of `ws.rx_data` and drop final output copy
- update tests and tx path to use cached maps

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a181616483299456a90d2f633d02