### PR TITLE
docs: expand README for utilities and loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,40 @@
-# LoRa Lite — Milestone 1 (Tables & Utilities)
+# LoRa Lite PHY — Utilities & Loopback
 
-This folder contains the initial utility modules for the MVP:
-- `gray` (encode/decode + inverse table generator)
-- `whitening` (configurable LFSR, pre-set PN9 helper)
-- `hamming` (placeholders for CR 4/5..4/8 with a stable API)
-- `interleaver` (placeholder diagonal mapping and dimensions)
+This repository hosts the first pieces of a stand‑alone LoRa® physical layer.  
+Current focus is on reusable utility modules and a deterministic loopback
+transmitter/receiver pair used for bring‑up and testing.
 
-Build & test:
+## Utility modules
+- `gray` – encode/decode helpers and inverse table generation
+- `whitening` – configurable LFSR with a PN9 helper
+- `hamming` – CR 4/5 through 4/8 encode/decode tables
+- `interleaver` – diagonal mapping and size helpers
+
+## Loopback TX/RX
+`lora/tx/loopback_tx.hpp` converts a payload into IQ samples, while
+`lora/rx/loopback_rx.hpp` demodulates those samples back to bytes and checks the
+CRC.  The end‑to‑end loopback exercise is demonstrated in
+`tests/test_loopback.cpp`.
+
+## Build
 ```bash
 cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j"$(nproc)"
-cd build && ctest --output-on-failure
 ```
+
+## Run tests
+```bash
+cd build
+ctest --output-on-failure             # run all tests
+ctest -R Loopback --output-on-failure # run only loopback test
+```
+
+## Remaining MVP work
+- Integrate a single FFT backend and precomputed chirps
+- Complete TX/RX pipeline over preallocated buffers
+- Cross-validate against `gr-lora_sdr` vectors and capture performance metrics
+- Add basic synchronization (preamble detection and timing/Fo offset)
+
+See [LoRa_Lite_Migration_Plan_README.md](LoRa_Lite_Migration_Plan_README.md)
+for detailed roadmap and context.
+


### PR DESCRIPTION
## Summary
- describe available utility modules
- document loopback TX/RX pair and how to run tests
- note remaining MVP work with link to migration plan

## Testing
- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j"$(nproc)"`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b7b346084c8329a84caa7fe3a5d9b6