### PR TITLE
Fix lite decoder misalignment

### DIFF
--- a/src/rx/frame.cpp
+++ b/src/rx/frame.cpp
@@ -348,7 +348,8 @@ std::pair<std::span<uint8_t>, bool> decode_frame_with_preamble_cfo_sto_os_auto(
         float dn1 = corr_mag(s1, ws.downchirp.data());
         float up2 = corr_mag(s2, ws.upchirp.data());
         float dn2 = corr_mag(s2, ws.downchirp.data());
-        if (dn1 > up1 && dn2 > up2) {
+        const float ratio = 2.0f;
+        if (dn1 > up1 * ratio && dn2 > up2 * ratio) {
             // Advance start by 2 downchirps + quarter symbol
             sync_start += (2u * N + N/4u);
         }


### PR DESCRIPTION
## Summary
- include LoRa SFD pattern in lite IQ generator
- make downchirp skip in decoder less sensitive to random payload symbols

## Testing
- `python3 scripts/lite_matrix.py --quick`
- `ctest --output-on-failure` *(fails: ReferenceVectors.CrossValidate)*


------
https://chatgpt.com/codex/tasks/task_e_68bbe52537608329837385115d4518d9