### PR TITLE
Align header start with CFO/STO corrections

### DIFF
--- a/include/lora/rx/frame_align.hpp
+++ b/include/lora/rx/frame_align.hpp
@@ -8,8 +8,11 @@
 
 namespace lora::rx {
 
-// Detects preamble, corrects CFO/STO, aligns to sync, and returns samples
-// starting at the header.
+// Detects the preamble (using `detect_preamble_os`), estimates and
+// compensates CFO/STO (via `estimate_cfo_from_preamble`), aligns to the
+// sync word, and returns the corrected samples along with the index of
+// the header start. The returned `size_t` is `hdr_start_base`, defined as
+// `sync_start + 2*N + N/4` where `N` is the symbol length.
 std::optional<std::pair<std::vector<std::complex<float>>, size_t>>
 align_and_extract_data(
     Workspace& ws,

--- a/src/rx/frame_align.cpp
+++ b/src/rx/frame_align.cpp
@@ -22,34 +22,32 @@ align_and_extract_data(
     size_t sync_start = align_res->second;
     auto aligned = std::span<const std::complex<float>>(aligned_vec);
 
-    {
-        ws.init(sf);
-        uint32_t N = ws.N;
-        if (sync_start + N + N <= aligned.size()) {
-            uint32_t ss2 = demod_symbol_peak(ws, &aligned[sync_start + N]);
-            if (ss2 == expected_sync) {
-                sync_start += N;
-            }
+    ws.init(sf);
+    uint32_t N = ws.N;
+    if (sync_start + N + N <= aligned.size()) {
+        uint32_t ss2 = demod_symbol_peak(ws, &aligned[sync_start + N]);
+        if (ss2 == expected_sync) {
+            sync_start += N;
         }
-        auto corr_mag = [&](size_t idx, const std::complex<float>* ref) -> float {
-            std::complex<float> acc(0.f, 0.f);
-            if (idx + N > aligned.size()) return 0.f;
-            for (uint32_t n = 0; n < N; ++n) acc += aligned[idx + n] * std::conj(ref[n]);
-            return std::abs(acc);
-        };
-        size_t s1 = sync_start + N;
-        size_t s2 = s1 + N;
-        float up1 = corr_mag(s1, ws.upchirp.data());
-        float dn1 = corr_mag(s1, ws.downchirp.data());
-        float up2 = corr_mag(s2, ws.upchirp.data());
-        float dn2 = corr_mag(s2, ws.downchirp.data());
-        const float ratio = 2.0f;
-        (void)up1; (void)dn1; (void)up2; (void)dn2; (void)ratio;
-        sync_start += (2u * N + N/4u);
-        if (__dbg) printf("DEBUG: Advancing to header start at sync+2.25 symbols (sync_start=%zu)\n", sync_start);
     }
-
-    return std::pair<std::vector<std::complex<float>>, size_t>{std::move(aligned_vec), sync_start};
+    auto corr_mag = [&](size_t idx, const std::complex<float>* ref) -> float {
+        std::complex<float> acc(0.f, 0.f);
+        if (idx + N > aligned.size()) return 0.f;
+        for (uint32_t n = 0; n < N; ++n) acc += aligned[idx + n] * std::conj(ref[n]);
+        return std::abs(acc);
+    };
+    size_t s1 = sync_start + N;
+    size_t s2 = s1 + N;
+    float up1 = corr_mag(s1, ws.upchirp.data());
+    float dn1 = corr_mag(s1, ws.downchirp.data());
+    float up2 = corr_mag(s2, ws.upchirp.data());
+    float dn2 = corr_mag(s2, ws.downchirp.data());
+    const float ratio = 2.0f;
+    (void)up1; (void)dn1; (void)up2; (void)dn2; (void)ratio;
+    size_t hdr_start_base = sync_start + (2u * N + N/4u);
+    if (__dbg)
+        printf("DEBUG: Advancing to header start at sync+2.25 symbols (hdr_start_base=%zu)\n", hdr_start_base);
+    return std::pair<std::vector<std::complex<float>>, size_t>{std::move(aligned_vec), hdr_start_base};
 }
 
 } // namespace lora::rx

--- a/src/rx/frame_auto.cpp
+++ b/src/rx/frame_auto.cpp
@@ -25,15 +25,15 @@ std::pair<std::span<uint8_t>, bool> decode_frame_with_preamble_cfo_sto_os_auto(
     auto align_res = align_and_extract_data(ws, samples, sf, min_preamble_syms, expected_sync);
     if (!align_res) return {std::span<uint8_t>{}, false};
     auto aligned_vec = std::move(align_res->first);
-    size_t data_start = align_res->second;
+    size_t hdr_start_base = align_res->second;
     auto aligned = std::span<const std::complex<float>>(aligned_vec);
-    auto data = aligned.subspan(data_start);
+    auto data = aligned.subspan(hdr_start_base);
 
     uint32_t N = ws.N;
 
     if (__dbg) {
-        printf("DEBUG: Signal info - aligned.size()=%zu, sync_start=%zu, N=%u\n", aligned.size(), data_start, N);
-        printf("DEBUG: Data span - offset=%zu, data.size()=%zu\n", data_start + 3*N, data.size());
+        printf("DEBUG: Signal info - aligned.size()=%zu, hdr_start_base=%zu, N=%u\n", aligned.size(), hdr_start_base, N);
+        printf("DEBUG: Data span - offset=%zu, data.size()=%zu\n", hdr_start_base + 3*N, data.size());
     }
 
     const uint32_t header_cr_plus4 = 8u;


### PR DESCRIPTION
## Summary
- document align_and_extract_data's use of detect_preamble_os and CFO/STO estimation
- compute hdr_start_base = sync + 2*N + N/4 when aligning frames
- propagate hdr_start_base to frame auto decoder

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -LE slow` *(fails: RxSyncWord.Mismatch, Loopback.TxRx, reference.ReferenceVectors.CrossValidate, HeaderEndToEnd.PreambleSyncDecode, Preamble.DetectAndDecode, Preamble.CFOCompensation, Preamble.STOAlignment, Preamble.OS4DetectAndDecode, cli.json.os1, cli.json.os1.partial, cli.json.os4.partial, cross.validate.full)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e6f711e48329939e18fa498893bf