### PR TITLE
Document offline decoder payload symbol fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ conda run -n gnuradio-lora <command>
 
 With the helper scripts above you can generate a canonical vector, inspect GNU Radio's intermediate buffers, and then run either `./build/test_gr_pipeline` or `python3 scripts/decode_offline_recording_final.py` on the same file. The expectation is that the decoded payload bytes and CRC outcomes will match between the two implementations.
 
+## Debugging notes
+
+- See [`docs/offline_decode_investigation.md`](docs/offline_decode_investigation.md) for the post-mortem on a failure where the
+  offline decoder stopped after the header stage because the payload symbol count was hard-coded in the C++ pipeline. The notes
+  summarise the symptom observed via `scripts/decode_offline_recording_final.py`, the fix in `src/rx/gr_pipeline.cpp`, and the
+  open follow-ups that should be considered during future maintenance.
 
 ## New Pipeline Features
 

--- a/docs/offline_decode_investigation.md
+++ b/docs/offline_decode_investigation.md
@@ -1,0 +1,39 @@
+# Offline decode investigation
+
+## Summary
+- Running the offline decode helper against captures produced by GNU Radio (`python3 scripts/decode_offline_recording_final.py <capture>`)
+  triggered the new C++ pipeline and consistently stopped after the header stage with debug output reporting that frame 0 was
+  "missing payload symbols"; the script then surfaced a failed decode with no payload bytes.【F:scripts/decode_offline_recording_final.py†L75-L175】【F:src/rx/gr_pipeline.cpp†L414-L427】
+- The multi-frame decoder in `src/rx/gr_pipeline.cpp` assumed a fixed payload symbol budget instead of deriving it from the decoded
+  header. Any capture whose payload was shorter than the hard-coded count left the loop believing the payload symbols were
+  truncated, so it aborted without returning user data.【F:src/rx/gr_pipeline.cpp†L348-L429】
+- Computing the expected number of payload symbols from the header fields (payload length, coding rate, CRC flag) unblocks
+  the decoder for any valid payload length and restored the Python wrapper to working order.【F:src/rx/gr_pipeline.cpp†L28-L47】【F:src/rx/gr_pipeline.cpp†L348-L356】
+
+## Root cause analysis
+`decode_offline_recording_final.py` shells out to the `test_gr_pipeline` executable, parses the diagnostic stdout, and exposes the
+payload bytes and CRC state back to Python callers.【F:scripts/decode_offline_recording_final.py†L75-L155】【F:scripts/decode_offline_recording_final.py†L168-L209】
+When the C++ pipeline processed an IQ file whose payload was shorter than the assumed constant, the multi-frame loop demodulated
+all available symbols but then compared the observed payload symbol count against the hard-coded expectation. Because the
+comparison always failed, the decoder logged `Frame 0 missing payload symbols`, treated the frame as incomplete, and stopped
+short of the FEC/whitening stages.【F:src/rx/gr_pipeline.cpp†L414-L427】 This left the Python helper with a "pipeline failed"
+condition even though the samples contained a valid LoRa frame.
+
+## Corrective actions
+1. Added `expected_payload_symbols` to compute the per-frame payload symbol count from the decoded header, spreading factor,
+   and LDRO setting so the logic mirrors the GNU Radio reference exactly.【F:src/rx/gr_pipeline.cpp†L28-L47】
+2. Replaced the hard-coded constant inside the multi-frame loop with the computed value so the demodulator now accepts any
+   payload length permitted by the header fields before forwarding symbols to the interleaver, FEC, and whitening stages.【F:src/rx/gr_pipeline.cpp†L348-L356】【F:src/rx/gr_pipeline.cpp†L419-L437】
+
+## Open follow-ups
+- The pipeline still relies on the caller to seed `Config.header_symbol_count` (currently set to 16 in `test_gr_pipeline`). We should
+  move this derivation inside the pipeline so Python bindings or future tools cannot forget to initialise it.【F:test_gr_pipeline.cpp†L26-L40】【F:src/rx/gr_pipeline.cpp†L349-L420】
+- Add regression coverage that runs the C++ pipeline across multiple payload lengths via the Python harness, ensuring the JSON
+  parsing path exercised by `decode_offline_recording_final.py` stays healthy.【F:scripts/decode_offline_recording_final.py†L75-L209】
+- Convert the verbose debug prints that surfaced during this investigation (`Frame 0 missing payload symbols`, FFT dumps, etc.)
+  into structured logging so future triage can be filtered more easily.【F:src/rx/gr_pipeline.cpp†L352-L440】
+
+## Related files
+- Offline decode script: `scripts/decode_offline_recording_final.py`
+- GNU Radio compatible pipeline implementation: `src/rx/gr_pipeline.cpp`
+- Standalone CLI used by the script: `test_gr_pipeline.cpp`


### PR DESCRIPTION
## Summary
- add an investigation note covering the offline decoder failure caused by a hard-coded payload symbol budget
- link the new troubleshooting document from the README so future debugging sessions can find it quickly

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cfabc1097c8329b7c585cae06535e8