### PR TITLE
docs: log crc mismatch telemetry from offline decode

### DIFF
--- a/docs/offline_decode_investigation.md
+++ b/docs/offline_decode_investigation.md
@@ -10,7 +10,8 @@
 
 - Computing the expected number of payload symbols from the header fields (payload length, coding rate, CRC flag) unblocks the decoder for any valid payload length and restored the Python wrapper to working order.【F:src/rx/gr_pipeline.cpp†L28-L47】【F:src/rx/gr_pipeline.cpp†L348-L356】
 - Follow-up verification initially stalled because the container lacked `liquid-dsp`; CMake now falls back to the vendored `external/liquid-dsp` sources when the system library is absent so future rebuilds of `test_gr_pipeline` can proceed inside clean environments once `pybind11` is also available.【F:CMakeLists.txt†L8-L55】
-- Relaxed the offline decode helper so it accepts hexadecimal header fields, letting the investigation surface the 242-byte payload (CRC currently invalid) instead of crashing on the debug dump.【F:scripts/decode_offline_recording_final.py†L20-L175】【85ecd9†L1-L8】
+- Relaxed the offline decode helper so it accepts hexadecimal header fields, letting the investigation surface the 242-byte payload (CRC currently invalid) instead of crashing on the debug dump.【F:scripts/decode_offline_recording_final.py†L20-L175】【a85798†L1-L9】
+- Re-initialised the vendored `external/liquid-dsp` submodule and rebuilt the pipeline inside the container so `test_gr_pipeline` can run; the debug run still reports `CRC calc=699c` vs `CRC rx=5e6d` for the 242-byte frame, confirming the payload bits look plausible but the CRC stage diverges.【790c15†L1-L4】【7f750c†L1-L17】【f93ffd†L1-L2】【3a6e3f†L23-L36】
 
 
 ## Root cause analysis
@@ -32,11 +33,12 @@ condition even though the samples contained a valid LoRa frame.
 ## Verification status
 
 - Reconfigured the tree with `cmake -S . -B build -Dpybind11_DIR=/root/.local/lib/python3.12/site-packages/pybind11/share/cmake/pybind11` after initialising `external/liquid-dsp`; the configure step now completes and `cmake --build build` produces `test_gr_pipeline` alongside the Python extension.【434ab2†L1-L7】【06b1db†L1-L2】
-- Running `python3 scripts/decode_offline_recording_final.py vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown` now decodes one frame and prints the 242-byte payload with a failing CRC, confirming the parser fix and highlighting the remaining CRC mismatch.【85ecd9†L1-L8】
+- Running `python3 scripts/decode_offline_recording_final.py vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown` now decodes one frame and prints the 242-byte payload with a failing CRC, confirming the parser fix and highlighting the remaining CRC mismatch.【a85798†L1-L9】
+- Invoking `./build/test_gr_pipeline` against the same capture prints the Hamming-decoded nibbles, dewhitened payload bytes, and the mismatched CRC pair (`calc=699c`, `rx=5e6d`), giving concrete data for the next debugging step.【7adb98†L1-L18】【3a6e3f†L1-L36】【3cf043†L1-L19】
 
 ## Next steps
 
-- Investigate why the pipeline reports mismatched CRC values (`CRC calc=...`, `CRC rx=...`) on the sample capture so the remaining decoding error can be addressed.【ae6284†L36-L74】
+- Investigate why the pipeline reports mismatched CRC values (`CRC calc=699c`, `CRC rx=5e6d`) on the sample capture so the remaining decoding error can be addressed, validating the whitening offsets, nibble ordering, and CRC polynomial/endianness against the GNU Radio reference.【3a6e3f†L23-L36】
 - After the CRC mismatch is resolved, rerun the offline decode regression end-to-end and capture the successful output in this document to close the investigation and guard against future regressions.
 
 


### PR DESCRIPTION
## Summary
- document the rebuilt pipeline environment and note that the first frame still shows CRC calc=699c vs rx=5e6d
- record the new test_gr_pipeline logs exposing the Hamming nibbles and CRC mismatch for further analysis

## Testing
- python3 scripts/decode_offline_recording_final.py vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown
- ./build/test_gr_pipeline vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown

------
https://chatgpt.com/codex/tasks/task_e_68cfbb3bb0d08329a931235b559eb8ca