### PR TITLE
Clamp offline decode payload length for truncated captures

### DIFF
--- a/docs/offline_decode_investigation.md
+++ b/docs/offline_decode_investigation.md
@@ -13,6 +13,12 @@
 - Relaxed the offline decode helper so it accepts hexadecimal header fields, letting the investigation surface the 242-byte payload (CRC currently invalid) instead of crashing on the debug dump.【F:scripts/decode_offline_recording_final.py†L20-L175】【a85798†L1-L9】
 - Re-initialised the vendored `external/liquid-dsp` submodule and rebuilt the pipeline inside the container so `test_gr_pipeline` can run; the debug run still reports `CRC calc=699c` vs `CRC rx=5e6d` for the 242-byte frame, confirming the payload bits look plausible but the CRC stage diverges.【790c15†L1-L4】【7f750c†L1-L17】【f93ffd†L1-L2】【3a6e3f†L23-L36】
 - Re-ran the Python harness against the capture and confirmed the C++ CRC engine reproduces the `0x699c` checksum on the 242-byte payload while the on-air trailer still reads `0x5e6d`; recomputing the checksum with the captured trailer and sweeping whitening offsets leaves the mismatch unchanged, so the corruption must stem from an earlier demodulation/FEC stage rather than CRC parameters or dewhitening.【a8c3a5†L1-L10】【bfd100†L1-L2】【675f51†L1-L1】【7843c7†L1-L8】
+- Feeding the higher-rate capture `sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown`
+  exposed a second failure mode: the header advertises a 96-byte payload, but only ~18k baseband samples are present so the
+  multi-frame loop aborted before producing payload bytes.【ba19bc†L1-L24】 Adding a fallback that clamps the payload symbol
+  budget to the available samples and truncates the CRC expectation allows the helper to recover two partial frames (94 and
+  26 bytes) even though their CRCs remain invalid and the decoded text is still garbage, confirming the underlying FEC
+  corruption persists.【F:src/rx/gr_pipeline.cpp†L367-L383】【F:src/rx/gr_pipeline.cpp†L614-L719】【83e45b†L1-L52】【00689f†L1-L5】
 
 
 ## Root cause analysis
@@ -35,12 +41,18 @@ condition even though the samples contained a valid LoRa frame.
 
 - Reconfigured the tree with `cmake -S . -B build -Dpybind11_DIR=/root/.local/lib/python3.12/site-packages/pybind11/share/cmake/pybind11` after initialising `external/liquid-dsp`; the configure step now completes and `cmake --build build` produces `test_gr_pipeline` alongside the Python extension.【434ab2†L1-L7】【06b1db†L1-L2】
 - Running `python3 scripts/decode_offline_recording_final.py vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown` now decodes one frame and prints the 242-byte payload with a failing CRC, confirming the parser fix and highlighting the remaining CRC mismatch.【a85798†L1-L9】
+- Running the same helper against `sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown`
+  yields two truncated frames (94 and 26 bytes) with failing CRCs and non-sensical text, demonstrating that the new clamping
+  logic prevents the hard failure but the payload bits are still mangled upstream.【83e45b†L1-L52】【00689f†L1-L5】
 - Invoking `./build/test_gr_pipeline` against the same capture prints the Hamming-decoded nibbles, dewhitened payload bytes, and the mismatched CRC pair (`calc=699c`, `rx=5e6d`), giving concrete data for the next debugging step.【7adb98†L1-L18】【3a6e3f†L1-L36】【3cf043†L1-L19】
 - Verified with a standalone Python script that the pipeline’s CRC calculator still yields `0x699c` when run over the dewhitened payload bytes and that appending the captured CRC (`0x5e6d`) does not zero the remainder; rotating the whitening sequence at the nibble level across eight offsets also leaves both values unchanged, eliminating simple CRC or whitening misconfiguration as causes.【bfd100†L1-L2】【675f51†L1-L1】【7843c7†L1-L8】
 
 ## Next steps
 
 - Investigate why the pipeline reports mismatched CRC values (`CRC calc=699c`, `CRC rx=5e6d`) on the sample capture by tracing back through the payload demodulation stack—deinterleaving, Hamming decode, and nibble assembly—to spot the corruption that survives CRC recomputation despite matching whitening and polynomial settings.【3a6e3f†L23-L36】【7843c7†L1-L8】
+- Extend that investigation to the 500 ksps capture: even with payload clamping and MSB-first bit ordering, the first
+  frame’s codewords still decode to incorrect nibbles and the recovered bytes never contain `hello_stupid_world`, so the FEC
+  stages or Gray mapping are still misaligned for higher-rate captures.【F:src/rx/gr_pipeline.cpp†L519-L575】【83e45b†L24-L46】【00689f†L1-L5】
 - After the CRC mismatch is resolved, rerun the offline decode regression end-to-end and capture the successful output in this document to close the investigation and guard against future regressions.
 
 


### PR DESCRIPTION
## Summary
- clamp the payload symbol budget to the available samples and derive an effective payload/CRC size so truncated captures no longer abort the offline decoder
- switch the payload symbol bit extraction back to MSB-first and record the partial results for the 500 ksps capture in the investigation log

## Testing
- cmake --build build
- python3 scripts/decode_offline_recording_final.py vectors/sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown


------
https://chatgpt.com/codex/tasks/task_e_68cfd90b7d2083298721ac2970611b83