### PR TITLE
Align diagonal interleaver mapping with GNU Radio

### DIFF
--- a/src/rx/gr/utils.cpp
+++ b/src/rx/gr/utils.cpp
@@ -27,10 +27,14 @@ InterleaverMap make_diagonal_interleaver(uint32_t sf, uint32_t cr_plus4) {
     for (uint32_t col = 0; col < cols; ++col) {
         for (uint32_t row = 0; row < rows; ++row) {
             uint32_t dst = col * rows + row;
-            int rotated = static_cast<int>(row) - static_cast<int>(col);
+
+            // GNU Radio diagonal interleaver uses mod((i - j - 1), sf) to select
+            // the destination row for a given input column i and row j.
+            int rotated = static_cast<int>(col) - static_cast<int>(row) - 1;
             rotated %= static_cast<int>(rows);
-            if (rotated < 0) rotated += rows;
-            uint32_t src = rotated * cols + col;
+            if (rotated < 0) rotated += static_cast<int>(rows);
+
+            uint32_t src = static_cast<uint32_t>(rotated) * cols + col;
             map.map[dst] = src;
         }
     }


### PR DESCRIPTION
## Summary
- match the diagonal interleaver mapping to GNU Radio's mod((i - j - 1), sf) rotation
- document the updated investigation results and remaining CRC/symbol issues for the 500 ksps capture

## Testing
- cmake --build build
- python3 scripts/decode_offline_recording_final.py vectors/sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown

------
https://chatgpt.com/codex/tasks/task_e_68cfde54d8188329a8279e5c1db96d25