### PR TITLE
Inspect payload whitening in offline decode pipeline

### DIFF
--- a/src/rx/gr/utils.cpp
+++ b/src/rx/gr/utils.cpp
@@ -98,7 +98,7 @@ HammingTables make_hamming_tables() {
         for (int i = 0; i < nbits; ++i) {
             uint16_t cw = base ^ (1u << i);
             uint8_t syn = compute_syndrome(cw, nbits);
-            if (syn < arr.size())
+            if (syn < arr.size() && arr[syn] < 0)
                 arr[syn] = static_cast<int8_t>(i);
         }
     };


### PR DESCRIPTION
## Summary
- Convert decoded nibbles into raw bytes before whitening so the pipeline can log the on-air byte stream and then apply `dewhiten_payload` to the payload portion for easier debugging of corrupt symbols.【F:src/rx/gr_pipeline.cpp†L646-L678】
- Prevent the Hamming syndrome LUT builder from overwriting existing entries while generating decode tables for the various code rates.【F:src/rx/gr/utils.cpp†L96-L103】
- Extend `docs/offline_decode_investigation.md` with the new byte-level whitening observations and updated next steps for comparing the captured stream against a reference encoder.【F:docs/offline_decode_investigation.md†L3-L65】

## Testing
- `cmake --build build`【2afd13†L1-L9】
- `python3 scripts/decode_offline_recording_final.py vectors/sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown`【9508e8†L1-L16】
- `python3 scripts/decode_offline_recording_final.py vectors/sps_125k_bw_125k_sf_7_cr_1_ldro_false_crc_true_implheader_false_nmsgs_8.unknown`【e27686†L1-L18】

------
https://chatgpt.com/codex/tasks/task_e_68cfea467c508329ac2d367de763b28f