### PR TITLE
Include string header in scheduler

### DIFF
--- a/src/rx/scheduler/scheduler.cpp
+++ b/src/rx/scheduler/scheduler.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <vector>
 #include <chrono>
+#include <string>
 
 #include "lora/rx/gr/primitives.hpp"
 #include "lora/rx/gr/header_decode.hpp"


### PR DESCRIPTION
## Summary
- include `<string>` in the scheduler implementation so string usage compiles cleanly

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d29e10d0a083298b43833e232d1898