### PR TITLE
Set HeaderResult defaults to zero

### DIFF
--- a/include/lora/rx/scheduler.hpp
+++ b/include/lora/rx/scheduler.hpp
@@ -82,12 +82,12 @@ struct LocateHeaderResult {
 
 struct HeaderResult {
     bool   ok = false;
-    uint8_t sf = 7;
-    uint8_t cr_idx = 1;  // 1→4/5, 2→4/6, ...
+    uint8_t sf = 0;
+    uint8_t cr_idx = 0;  // 1→4/5, 2→4/6, ...
     bool ldro = false;
-    bool has_crc = true;
+    bool has_crc = false;
     uint16_t payload_len_bytes = 0;
-    size_t header_syms = 16; // always 16 in LoRa explicit
+    size_t header_syms = 0; // set to 16 for LoRa explicit headers when decoded
     uint32_t detected_os = 0;
     int detected_phase = 0;
     size_t det_start_raw = 0;

--- a/src/rx/scheduler/scheduler.hpp
+++ b/src/rx/scheduler/scheduler.hpp
@@ -70,12 +70,12 @@ struct LocateHeaderResult {
 
 struct HeaderResult {
     bool   ok = false;
-    uint8_t sf = 7;
-    uint8_t cr_idx = 1;  // 1→4/5, 2→4/6, ...
+    uint8_t sf = 0;
+    uint8_t cr_idx = 0;  // 1→4/5, 2→4/6, ...
     bool ldro = false;
-    bool has_crc = true;
+    bool has_crc = false;
     uint16_t payload_len_bytes = 0;
-    size_t header_syms = 16; // always 16 in LoRa explicit
+    size_t header_syms = 0; // set to 16 for LoRa explicit headers when decoded
 };
 
 struct PayloadResult {


### PR DESCRIPTION
## Summary
- initialize HeaderResult decoding fields to zero/false so default construction matches scheduler unit test expectations
- document that header symbol count is populated during decoding and mirror the change in the internal scheduler header

## Testing
- `cmake --build build --target test_scheduler`
- `./build/test_scheduler`


------
https://chatgpt.com/codex/tasks/task_e_68d29f7783c4832984a1fe9704d25fb1