### PR TITLE
Adjust payload symbol estimation for CRC flag

### DIFF
--- a/include/lora/rx/scheduler.hpp
+++ b/include/lora/rx/scheduler.hpp
@@ -113,7 +113,8 @@ struct PayloadResult {
 DetectPreambleResult detect_preamble_dynamic(const cfloat* raw, size_t raw_len, const RxConfig& cfg, size_t history_raw);
 LocateHeaderResult   locate_header_start(const cfloat* raw, size_t raw_len, const RxConfig& cfg, const DetectPreambleResult& d);
 HeaderResult         demod_header(const cfloat* raw, size_t raw_len, const RxConfig& cfg, const LocateHeaderResult& h, const DetectPreambleResult& d);
-size_t               expected_payload_symbols(uint16_t pay_len, uint8_t cr_idx, bool ldro, uint8_t sf); // exists
+size_t               expected_payload_symbols(uint16_t pay_len, uint8_t cr_idx, bool ldro, uint8_t sf,
+                                              bool has_crc, bool implicit_header = false); // exists
 PayloadResult        demod_payload(const cfloat* raw, size_t raw_len, const RxConfig& cfg,
                                    const HeaderResult& hdr, const DetectPreambleResult& d, size_t header_start_raw);
 

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -188,17 +188,21 @@ void test_expected_payload_symbols() {
     std::cout << "Testing expected_payload_symbols..." << std::endl;
     
     // Test with different parameters
-    size_t symbols1 = expected_payload_symbols(10, 1, false, 7); // SF=7, CR=1, no LDRO
-    assert(symbols1 > 0);
-    
-    size_t symbols2 = expected_payload_symbols(10, 1, true, 7); // SF=7, CR=1, with LDRO
+    size_t symbols1 = expected_payload_symbols(10, 1, false, 7, true); // SF=7, CR=1, no LDRO, CRC on
+    assert(symbols1 == 28);
+
+    size_t symbols2 = expected_payload_symbols(10, 1, true, 7, true); // SF=7, CR=1, with LDRO, CRC on
     assert(symbols2 > 0);
-    
-    size_t symbols3 = expected_payload_symbols(10, 3, false, 8); // SF=8, CR=3, no LDRO
+
+    size_t symbols3 = expected_payload_symbols(10, 3, false, 8, true); // SF=8, CR=3, no LDRO, CRC on
     assert(symbols3 > 0);
-    
+
     // LDRO should affect the calculation
     assert(symbols1 != symbols2);
+
+    size_t symbols_no_crc = expected_payload_symbols(10, 1, false, 7, false); // CRC off
+    assert(symbols_no_crc == 23);
+    assert(symbols_no_crc < symbols1);
     
     std::cout << "expected_payload_symbols tests passed!" << std::endl;
 }


### PR DESCRIPTION
## Summary
- add CRC (and optional implicit header) parameters to `expected_payload_symbols`
- use the header CRC flag when estimating payload symbols during demodulation
- extend scheduler unit tests to cover CRC-disabled payload calculations

## Testing
- cmake -S . -B build *(fails: Could not find liquid-dsp)*

------
https://chatgpt.com/codex/tasks/task_e_68d2adb5e0748329a852b9da8d8de0fd