### PR TITLE
Adjust explicit header symbol count handling

### DIFF
--- a/include/lora/rx/scheduler.hpp
+++ b/include/lora/rx/scheduler.hpp
@@ -88,7 +88,7 @@ struct HeaderResult {
     bool ldro = false;
     bool has_crc = false;
     uint16_t payload_len_bytes = 0;
-    size_t header_syms = 0; // set to 16 for LoRa explicit headers when decoded
+    size_t header_syms = 0; // set to 8 for LoRa explicit headers when decoded
     uint32_t detected_os = 0;
     int detected_phase = 0;
     size_t det_start_raw = 0;
@@ -244,7 +244,7 @@ struct Scheduler {
             DEBUGF("PAY: ok=%d payload_syms=%zu consumed_raw=%zu crc_ok=%d",
                    int(ctx.p.ok), ctx.p.payload_syms, ctx.p.consumed_raw, int(ctx.p.crc_ok));
 
-            // Account for header length (16 symbols) if demod_payload didn't include consumption:
+            // Account for header length (ctx.h.header_syms symbols) if demod_payload didn't include consumption:
             const size_t header_raw = dec_syms_to_raw_samples(ctx.h.header_syms, cfg);
             const size_t consumed_raw_total = header_raw + ctx.p.consumed_raw;
             ctx.frame_end_raw = ctx.frame_start_raw + consumed_raw_total;

--- a/src/rx/scheduler/scheduler.cpp
+++ b/src/rx/scheduler/scheduler.cpp
@@ -127,7 +127,7 @@ HeaderResult demod_header(const cfloat* raw, size_t raw_len, const RxConfig& cfg
     ret.ldro = cfg.ldro;
     ret.has_crc = header->has_crc;
     ret.payload_len_bytes = header->payload_len;
-    ret.header_syms = 16;
+    ret.header_syms = 8;
 
     switch (header->cr) {
         case lora::rx::gr::CodeRate::CR45: ret.cr_idx = 1; break;

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -146,7 +146,7 @@ void test_header_result() {
     result.ldro = false;
     result.has_crc = true;
     result.payload_len_bytes = 10;
-    result.header_syms = 16;
+    result.header_syms = 8;
     
     assert(result.ok == true);
     assert(result.sf == 7);
@@ -154,7 +154,7 @@ void test_header_result() {
     assert(result.ldro == false);
     assert(result.has_crc == true);
     assert(result.payload_len_bytes == 10);
-    assert(result.header_syms == 16);
+    assert(result.header_syms == 8);
     
     std::cout << "HeaderResult tests passed!" << std::endl;
 }


### PR DESCRIPTION
## Summary
- set the decoded HeaderResult to report the LoRa explicit header's eight symbols
- rely on the updated header symbol count when advancing the scheduler and update the unit test expectations

## Testing
- ./build/test_scheduler
- ./build/test_gr_pipeline vectors/sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown

------
https://chatgpt.com/codex/tasks/task_e_68d2b8765de48329ad1f5fd9022861dc