### PR TITLE
Improve FFT demod shift scoring

### DIFF
--- a/standalone/include/dsp.hpp
+++ b/standalone/include/dsp.hpp
@@ -26,6 +26,10 @@ uint32_t demod_symbol_peak_cfo(std::span<const std::complex<float>> block,
                                float eps);
 
 // FFT-based demod: dechirp (with optional CFO) then FFT and pick max-magnitude bin
+struct FFTBinPeak { uint32_t bin; float power; };
+FFTBinPeak demod_symbol_peak_fft_with_power(std::span<const std::complex<float>> block,
+                                            std::span<const std::complex<float>> downchirp,
+                                            float eps = 0.0f);
 uint32_t demod_symbol_peak_fft(std::span<const std::complex<float>> block,
                                std::span<const std::complex<float>> downchirp,
                                float eps = 0.0f);


### PR DESCRIPTION
## Summary
- add an FFT demod helper that reports the peak bin together with its FFT power
- rank best-shift candidates using the true FFT power instead of a placeholder heuristic

## Testing
- cmake -S standalone -B standalone/build
- cmake --build standalone/build -j


------
https://chatgpt.com/codex/tasks/task_e_68d3b10f25388329854f985c264f5ebe