### PR TITLE
Include <bit> for standalone DSP build

### DIFF
--- a/standalone/src/dsp.cpp
+++ b/standalone/src/dsp.cpp
@@ -1,5 +1,6 @@
 #include "dsp.hpp"
 #include <algorithm>
+#include <bit>
 #include <cmath>
 
 namespace lora::standalone {


### PR DESCRIPTION
## Summary
- add the missing `<bit>` standard header to `standalone/src/dsp.cpp` so the standalone build can use std::bit utilities

## Testing
- cmake -S standalone -B standalone/build
- cmake --build standalone/build -j

------
https://chatgpt.com/codex/tasks/task_e_68d3b3954c508329bef56c8adade3125