### PR TITLE
Add payload diagnostics and debug tooling

### DIFF
--- a/scripts/check_deinterleaver.py
+++ b/scripts/check_deinterleaver.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Cross-check diagonal deinterleaver output against a Python reference."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "standalone" / "build" / "lora_rx"
+
+
+CASES = [
+    {
+        "file": REPO_ROOT / "vectors" / "test_short_payload.unknown",
+        "sf": 7,
+        "bw": 125000,
+        "fs": 250000,
+    },
+    {
+        "file": REPO_ROOT
+        / "vectors"
+        / "sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown",
+        "sf": 7,
+        "bw": 125000,
+        "fs": 500000,
+    },
+]
+
+
+def run_case(case: dict) -> dict:
+    cmd = [
+        str(CLI_PATH),
+        "--json",
+        "--dump-bits",
+        str(case["file"]),
+        str(case["sf"]),
+        str(case["bw"]),
+        str(case["fs"]),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    try:
+        return json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"Failed to parse JSON for {case['file']}: {exc}\n{result.stdout}") from exc
+
+
+def diag_deinterleave(rows: int, cols: int, inter_bits: list[int]) -> list[int]:
+    expected = [0] * (rows * cols)
+    for col in range(cols):
+        for row in range(rows):
+            dest = (col - row - 1) % rows
+            expected[dest * cols + col] = inter_bits[col * rows + row]
+    return expected
+
+
+def validate_header(data: dict) -> None:
+    rows = data.get("header_rows", 0)
+    cols = data.get("header_cols", 0)
+    if not rows or not cols:
+        return
+    inter = data.get("header_inter_bits", [])
+    deinter = data.get("header_deinter_bits", [])
+    assert len(inter) == rows * cols, "Header interleaver size mismatch"
+    expected = diag_deinterleave(rows, cols, inter)
+    assert expected == deinter, "Header deinterleaver mismatch"
+
+
+def validate_payload(data: dict) -> None:
+    blocks = data.get("payload_blocks", [])
+    for idx, block in enumerate(blocks):
+        rows = block.get("rows", 0)
+        cols = block.get("cols", 0)
+        inter = block.get("inter_bits", [])
+        deinter = block.get("deinter_bits", [])
+        assert len(inter) == rows * cols, f"Payload block {idx} inter size mismatch"
+        expected = diag_deinterleave(rows, cols, inter)
+        assert expected == deinter, f"Payload block {idx} mismatch"
+
+
+def main() -> int:
+    if not CLI_PATH.exists():
+        print(f"CLI not found at {CLI_PATH}. Build the standalone project first.", file=sys.stderr)
+        return 2
+    any_fail = False
+    for case in CASES:
+        data = run_case(case)
+        try:
+            validate_header(data)
+            validate_payload(data)
+        except AssertionError as exc:
+            any_fail = True
+            print(f"[FAIL] {case['file'].name}: {exc}")
+            continue
+        print(
+            f"[OK] {case['file'].name}: header rows={data.get('header_rows')} payload blocks={len(data.get('payload_blocks', []))}"
+        )
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_payload_boundaries.py
+++ b/scripts/validate_payload_boundaries.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate header/payload boundaries and CRC handling across reference vectors."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "standalone" / "build" / "lora_rx"
+
+
+CASES = [
+    {
+        "file": REPO_ROOT
+        / "vectors"
+        / "sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown",
+        "sf": 7,
+        "bw": 125000,
+        "fs": 500000,
+    }
+]
+
+
+def run_case(case: dict) -> dict:
+    cmd = [
+        str(CLI_PATH),
+        "--json",
+        "--debug-crc",
+        str(case["file"]),
+        str(case["sf"]),
+        str(case["bw"]),
+        str(case["fs"]),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    try:
+        data = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"Failed to parse JSON output for {case['file']}: {exc}\n{result.stdout}") from exc
+    return data
+
+
+def validate(data: dict) -> None:
+    payload_len = data.get("payload_len", -1)
+    payload_bytes = data.get("payload_bytes", [])
+    has_crc = bool(data.get("has_crc", False))
+    expected = payload_len + (2 if has_crc else 0)
+    assert len(payload_bytes) == expected, (
+        f"payload byte count mismatch: expected {expected}, got {len(payload_bytes)}"
+    )
+    if has_crc:
+        assert data.get("payload_crc_semtech_ok", False), "Semtech CRC check failed"
+        trace = data.get("payload_crc_trace", [])
+        assert len(trace) == len(payload_bytes), "CRC trace length mismatch"
+        prns = data.get("payload_whitening_prns", [])
+        assert len(prns) == payload_len, "Whitening sequence length mismatch"
+
+
+def main() -> int:
+    if not CLI_PATH.exists():
+        print(f"CLI not found at {CLI_PATH}. Build the standalone project first.", file=sys.stderr)
+        return 2
+    any_fail = False
+    for case in CASES:
+        data = run_case(case)
+        try:
+            validate(data)
+        except AssertionError as exc:
+            any_fail = True
+            print(f"[FAIL] {case['file'].name}: {exc}")
+            continue
+        msg = "ok" if data.get("payload_crc_semtech_ok") else "crc-fail"
+        print(
+            f"[OK] {case['file'].name}: payload_len={data.get('payload_len')} bytes={len(data.get('payload_bytes', []))} ({msg})"
+        )
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/standalone/include/state_machine.hpp
+++ b/standalone/include/state_machine.hpp
@@ -13,6 +13,10 @@ struct RxConfig {
     uint32_t fs{250000};
     uint32_t os{2}; // fs/bw
     uint32_t preamble_min{8};
+    bool debug_detection{false};
+    bool capture_header_bits{false};
+    bool capture_payload_blocks{false};
+    bool trace_crc{false};
 };
 
 struct FrameOut {
@@ -30,6 +34,44 @@ struct FrameOut {
     // Decoded payload results (when implemented)
     std::vector<uint8_t> payload_bytes;
     bool payload_crc_ok{false};
+    // Diagnostics
+    float cfo_fraction{0.f};
+    int cfo_integer{0};
+    bool sfd_found{false};
+    size_t sfd_decim_pos{0};
+    std::vector<uint8_t> header_interleaver_bits;
+    std::vector<uint8_t> header_deinterleaver_bits;
+    uint32_t header_rows{0};
+    uint32_t header_cols{0};
+    struct PayloadBlockBits {
+        uint32_t rows{0};
+        uint32_t cols{0};
+        size_t symbol_offset{0};
+        std::vector<uint8_t> inter_bits;   // column-major layout
+        std::vector<uint8_t> deinter_bits; // row-major layout matching decode order
+    };
+    std::vector<PayloadBlockBits> payload_blocks_bits;
+    std::vector<uint8_t> payload_bytes_raw;
+    std::vector<uint8_t> payload_whitening_prns;
+    struct PayloadTraceEntry {
+        int index{0};
+        uint8_t raw_byte{0};
+        uint8_t whitening{0};
+        uint8_t dewhitened{0};
+        uint16_t crc_semtech_before{0};
+        uint16_t crc_semtech_after{0};
+        uint16_t crc_gr_before{0};
+        uint16_t crc_gr_after{0};
+        bool counted_semtech{false};
+        bool counted_gr{false};
+        bool is_crc_byte{false};
+    };
+    std::vector<PayloadTraceEntry> payload_crc_trace;
+    uint16_t payload_crc_semtech{0};
+    uint16_t payload_crc_gr{0};
+    uint16_t payload_crc_rx{0};
+    bool payload_crc_semtech_ok{false};
+    bool payload_crc_gr_ok{false};
 };
 
 enum class RxState { SEARCH_PREAMBLE, LOCATE_HEADER, DEMOD_HEADER, DEMOD_PAYLOAD };

--- a/standalone/src/main.cpp
+++ b/standalone/src/main.cpp
@@ -1,8 +1,12 @@
 #include "state_machine.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
 #include <vector>
 
 using namespace lora::standalone;
@@ -22,25 +26,62 @@ static bool read_iq_f32(const char* path, std::vector<std::complex<float>>& out)
     return true;
 }
 
+static void print_usage(const char* prog)
+{
+    std::fprintf(stderr,
+                 "Usage: %s [--json] [--debug-crc] [--dump-bits] [--debug-detect] <iq_f32_file> [sf=7] [bw=125000] [fs=250000]\n",
+                 prog);
+}
+
 int main(int argc, char** argv)
 {
-    if (argc < 2) {
-        std::fprintf(stderr, "Usage: %s <iq_f32_file> [sf=7] [bw=125000] [fs=250000]\n", argv[0]);
+    bool json_output = false;
+    bool debug_crc = false;
+    bool dump_bits = false;
+    bool debug_detection = false;
+    std::vector<std::string> positional;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--json") json_output = true;
+        else if (arg == "--debug-crc") debug_crc = true;
+        else if (arg == "--dump-bits") dump_bits = true;
+        else if (arg == "--debug-detect") debug_detection = true;
+        else if (arg == "--help" || arg == "-h") { print_usage(argv[0]); return 0; }
+        else if (!arg.empty() && arg[0] == '-' && arg != "-") {
+            std::fprintf(stderr, "Unknown option: %s\n", arg.c_str());
+            print_usage(argv[0]);
+            return 1;
+        } else {
+            positional.push_back(arg);
+        }
+    }
+    if (positional.empty()) {
+        print_usage(argv[0]);
         return 1;
     }
-    const char* path = argv[1];
-    uint32_t sf = (argc > 2) ? static_cast<uint32_t>(std::atoi(argv[2])) : 7u;
-    uint32_t bw = (argc > 3) ? static_cast<uint32_t>(std::atoi(argv[3])) : 125000u;
-    uint32_t fs = (argc > 4) ? static_cast<uint32_t>(std::atoi(argv[4])) : 250000u;
-    uint32_t os = fs / bw;
+
+    const std::string path = positional[0];
+    uint32_t sf = (positional.size() > 1) ? static_cast<uint32_t>(std::strtoul(positional[1].c_str(), nullptr, 10)) : 7u;
+    uint32_t bw = (positional.size() > 2) ? static_cast<uint32_t>(std::strtoul(positional[2].c_str(), nullptr, 10)) : 125000u;
+    uint32_t fs = (positional.size() > 3) ? static_cast<uint32_t>(std::strtoul(positional[3].c_str(), nullptr, 10)) : 250000u;
+    uint32_t os = (bw ? fs / bw : 1u);
 
     std::vector<std::complex<float>> iq;
-    if (!read_iq_f32(path, iq)) {
-        std::fprintf(stderr, "Failed to read %s\n", path);
+    if (!read_iq_f32(path.c_str(), iq)) {
+        std::fprintf(stderr, "Failed to read %s\n", path.c_str());
         return 2;
     }
 
-    RxConfig cfg; cfg.sf = sf; cfg.bw = bw; cfg.fs = fs; cfg.os = os; cfg.preamble_min = 8;
+    RxConfig cfg;
+    cfg.sf = sf;
+    cfg.bw = bw;
+    cfg.fs = fs;
+    cfg.os = os;
+    cfg.preamble_min = 8;
+    cfg.debug_detection = debug_detection;
+    cfg.capture_header_bits = dump_bits;
+    cfg.capture_payload_blocks = dump_bits || debug_crc;
+    cfg.trace_crc = debug_crc;
     Receiver rx(cfg);
 
     auto res = rx.process(iq);
@@ -48,6 +89,106 @@ int main(int argc, char** argv)
         std::fprintf(stderr, "No frame detected.\n");
         return 3;
     }
+    if (json_output) {
+        auto vec_to_string = [](auto const& vec) {
+            std::ostringstream oss;
+            oss << "[";
+            for (size_t idx = 0; idx < vec.size(); ++idx) {
+                if (idx) oss << ",";
+                oss << static_cast<long long>(vec[idx]);
+            }
+            oss << "]";
+            return oss.str();
+        };
+        auto vec32_to_string = [](auto const& vec) {
+            std::ostringstream oss;
+            oss << "[";
+            for (size_t idx = 0; idx < vec.size(); ++idx) {
+                if (idx) oss << ",";
+                oss << vec[idx];
+            }
+            oss << "]";
+            return oss.str();
+        };
+        std::vector<std::string> fields;
+        fields.push_back("\"start_sample\":" + std::to_string(res->start_sample));
+        fields.push_back("\"os\":" + std::to_string(res->os));
+        fields.push_back("\"phase\":" + std::to_string(res->phase));
+        fields.push_back("\"cfo_fraction\":" + std::to_string(res->cfo_fraction));
+        fields.push_back("\"cfo_integer\":" + std::to_string(res->cfo_integer));
+        fields.push_back("\"sfd_found\":" + std::string(res->sfd_found ? "true" : "false"));
+        fields.push_back("\"sfd_decim_pos\":" + std::to_string(res->sfd_decim_pos));
+        fields.push_back("\"payload_len\":" + std::to_string(res->payload_len));
+        fields.push_back("\"cr_idx\":" + std::to_string(res->cr_idx));
+        fields.push_back("\"has_crc\":" + std::string(res->has_crc ? "true" : "false"));
+        fields.push_back("\"header_crc_ok\":" + std::string(res->header_crc_ok ? "true" : "false"));
+        fields.push_back("\"payload_crc_ok\":" + std::string(res->payload_crc_ok ? "true" : "false"));
+        fields.push_back("\"payload_crc_semtech_ok\":" + std::string(res->payload_crc_semtech_ok ? "true" : "false"));
+        fields.push_back("\"payload_crc_gr_ok\":" + std::string(res->payload_crc_gr_ok ? "true" : "false"));
+        fields.push_back("\"payload_crc_semtech\":" + std::to_string(res->payload_crc_semtech));
+        fields.push_back("\"payload_crc_gr\":" + std::to_string(res->payload_crc_gr));
+        fields.push_back("\"payload_crc_rx\":" + std::to_string(res->payload_crc_rx));
+        fields.push_back("\"header_bins\":" + vec32_to_string(res->header_bins));
+        fields.push_back("\"payload_bins\":" + vec32_to_string(res->payload_bins));
+        fields.push_back("\"header_bits\":" + vec_to_string(res->header_bits));
+        fields.push_back("\"payload_bytes\":" + vec_to_string(res->payload_bytes));
+        fields.push_back("\"payload_bytes_raw\":" + vec_to_string(res->payload_bytes_raw));
+        fields.push_back("\"payload_whitening_prns\":" + vec_to_string(res->payload_whitening_prns));
+        if (res->header_rows && res->header_cols) {
+            fields.push_back("\"header_rows\":" + std::to_string(res->header_rows));
+            fields.push_back("\"header_cols\":" + std::to_string(res->header_cols));
+            fields.push_back("\"header_inter_bits\":" + vec_to_string(res->header_interleaver_bits));
+            fields.push_back("\"header_deinter_bits\":" + vec_to_string(res->header_deinterleaver_bits));
+        }
+        if (!res->payload_blocks_bits.empty()) {
+            std::ostringstream blocks;
+            blocks << "[";
+            for (size_t bi = 0; bi < res->payload_blocks_bits.size(); ++bi) {
+                if (bi) blocks << ",";
+                const auto& block = res->payload_blocks_bits[bi];
+                blocks << "{\"rows\":" << block.rows
+                       << ",\"cols\":" << block.cols
+                       << ",\"symbol_offset\":" << static_cast<unsigned long long>(block.symbol_offset)
+                       << ",\"inter_bits\":" << vec_to_string(block.inter_bits)
+                       << ",\"deinter_bits\":" << vec_to_string(block.deinter_bits)
+                       << "}";
+            }
+            blocks << "]";
+            fields.push_back("\"payload_blocks\":" + blocks.str());
+        }
+        if (!res->payload_crc_trace.empty()) {
+            std::ostringstream trace;
+            trace << "[";
+            for (size_t ti = 0; ti < res->payload_crc_trace.size(); ++ti) {
+                if (ti) trace << ",";
+                const auto& entry = res->payload_crc_trace[ti];
+                trace << "{\"index\":" << entry.index
+                      << ",\"raw\":" << static_cast<int>(entry.raw_byte)
+                      << ",\"whitening\":" << static_cast<int>(entry.whitening)
+                      << ",\"dewhitened\":" << static_cast<int>(entry.dewhitened)
+                      << ",\"crc_sem_before\":" << entry.crc_semtech_before
+                      << ",\"crc_sem_after\":" << entry.crc_semtech_after
+                      << ",\"crc_gr_before\":" << entry.crc_gr_before
+                      << ",\"crc_gr_after\":" << entry.crc_gr_after
+                      << ",\"count_sem\":" << (entry.counted_semtech ? "true" : "false")
+                      << ",\"count_gr\":" << (entry.counted_gr ? "true" : "false")
+                      << ",\"is_crc\":" << (entry.is_crc_byte ? "true" : "false")
+                      << "}";
+            }
+            trace << "]";
+            fields.push_back("\"payload_crc_trace\":" + trace.str());
+        }
+        std::ostringstream json;
+        json << "{";
+        for (size_t idx = 0; idx < fields.size(); ++idx) {
+            if (idx) json << ",";
+            json << fields[idx];
+        }
+        json << "}\n";
+        std::printf("%s", json.str().c_str());
+        return 0;
+    }
+
     std::printf("Frame start @ raw=%zu (os=%d phase=%d)\n", res->start_sample, res->os, res->phase);
     std::printf("Header bins (%zu): ", res->header_bins.size());
     for (size_t i = 0; i < res->header_bins.size(); ++i) std::printf(i ? ",%u" : "%u", res->header_bins[i]);
@@ -69,11 +210,34 @@ int main(int argc, char** argv)
         std::printf("Payload bytes (%zu): ", res->payload_bytes.size());
         for (size_t i = 0; i < res->payload_bytes.size(); ++i) std::printf(i ? " %02X" : "%02X", res->payload_bytes[i]);
         std::printf("\n");
-        if (res->has_crc) std::printf("Payload CRC: %s\n", res->payload_crc_ok ? "ok" : "not-ok");
+        if (res->has_crc) {
+            std::printf("Payload CRC (Semtech spec): %s\n", res->payload_crc_semtech_ok ? "ok" : "not-ok");
+            if (debug_crc) {
+                std::printf("Payload CRC (gr-lora-sdr variant): %s\n", res->payload_crc_gr_ok ? "ok" : "not-ok");
+                std::printf("CRC values: semtech=0x%04X gr=0x%04X rx=0x%04X\n",
+                            res->payload_crc_semtech, res->payload_crc_gr, res->payload_crc_rx);
+            }
+        }
     } else {
         std::printf("Payload bins (%zu): ", res->payload_bins.size());
         for (size_t i = 0; i < res->payload_bins.size(); ++i) std::printf(i ? ",%u" : "%u", res->payload_bins[i]);
         std::printf("\n");
+    }
+    if (debug_crc && !res->payload_crc_trace.empty()) {
+        std::printf("Idx Raw Dewhite PRN CRC_sem_before->after CRC_gr_before->after Flags\n");
+        for (const auto& entry : res->payload_crc_trace) {
+            std::printf("%3d 0x%02X 0x%02X 0x%02X %04X->%04X %04X->%04X %s%s\n",
+                        entry.index,
+                        entry.raw_byte,
+                        entry.dewhitened,
+                        entry.whitening,
+                        entry.crc_semtech_before,
+                        entry.crc_semtech_after,
+                        entry.crc_gr_before,
+                        entry.crc_gr_after,
+                        entry.counted_semtech ? "S" : "-",
+                        entry.counted_gr ? "G" : "-");
+        }
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add detection logging, payload interleaver capture, and Semtech CRC tracing to the standalone receiver
- extend the CLI with JSON/debug output modes and document the workflow in the top-level README
- add Python scripts that validate payload boundaries and diagonal deinterleaving against the CLI diagnostics

## Testing
- cmake -S standalone -B standalone/build
- cmake --build standalone/build -j
- scripts/validate_payload_boundaries.py
- scripts/check_deinterleaver.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b532ab8c8329b11644651cfb08a0