### PR TITLE
Fix whitening LFSR seed step to match spec

### DIFF
--- a/standalone/src/state_machine.cpp
+++ b/standalone/src/state_machine.cpp
@@ -302,13 +302,14 @@ std::vector<FrameOut> Receiver::run() {
         struct WhiteningLfsr {
             uint8_t state{0xFF};
             uint8_t step() {
+                uint8_t prn = state;
                 uint8_t b0 = (state >> 0) & 1u;
                 uint8_t b1 = (state >> 1) & 1u;
                 uint8_t b2 = (state >> 2) & 1u;
                 uint8_t b5 = (state >> 5) & 1u;
                 uint8_t next = static_cast<uint8_t>(b5 ^ b2 ^ b1 ^ b0);
                 state = static_cast<uint8_t>(((state << 1) | next) & 0xFFu);
-                return state;
+                return prn;
             }
         };
         auto crc16_step = [](uint16_t crc, uint8_t byte) {


### PR DESCRIPTION
## Summary
- correct the whitening LFSR helper so the first pseudo-noise value matches the reference (0xFF) instead of stepping immediately to 0xFE
- exercise the standalone receiver on the `hello_stupid_world` vector to confirm payload extraction and capture the decoded byte stream

## Testing
- python3 scripts/validate_payload_boundaries.py
- python3 scripts/check_deinterleaver.py

------
https://chatgpt.com/codex/tasks/task_e_68d3bf071ff88329983fe8972f3e771c