### PR TITLE
Fix whitening LFSR taps

### DIFF
--- a/standalone/src/state_machine.cpp
+++ b/standalone/src/state_machine.cpp
@@ -303,11 +303,11 @@ std::vector<FrameOut> Receiver::run() {
             uint8_t state{0xFF};
             uint8_t step() {
                 uint8_t prn = state;
-                uint8_t b0 = (state >> 0) & 1u;
-                uint8_t b1 = (state >> 1) & 1u;
-                uint8_t b2 = (state >> 2) & 1u;
-                uint8_t b5 = (state >> 5) & 1u;
-                uint8_t next = static_cast<uint8_t>(b5 ^ b2 ^ b1 ^ b0);
+                uint8_t b3 = static_cast<uint8_t>((state >> 3) & 1u);
+                uint8_t b4 = static_cast<uint8_t>((state >> 4) & 1u);
+                uint8_t b5 = static_cast<uint8_t>((state >> 5) & 1u);
+                uint8_t b7 = static_cast<uint8_t>((state >> 7) & 1u);
+                uint8_t next = static_cast<uint8_t>(b7 ^ b5 ^ b4 ^ b3);
                 state = static_cast<uint8_t>(((state << 1) | next) & 0xFFu);
                 return prn;
             }


### PR DESCRIPTION
## Summary
- correct the payload whitening LFSR taps to follow the LoRa FFh polynomial so PRNs match the reference table

## Testing
- standalone/build/lora_rx vectors/sps_500k_bw_125k_sf_7_cr_2_ldro_false_crc_true_implheader_false_hello_stupid_world.unknown 7 125000 500000
- python scripts/validate_payload_boundaries.py
- python scripts/check_deinterleaver.py

------
https://chatgpt.com/codex/tasks/task_e_68d3db955ecc8329b7274a845e25eb75